### PR TITLE
Add CMake build and threaded logging example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.26)
+project(EasyLoggerDemo C)
+
+set(CMAKE_C_STANDARD 99)
+
+add_subdirectory(easylogger)
+add_subdirectory(example)

--- a/demo/os/linux/easylogger/port/elog_port.c
+++ b/demo/os/linux/easylogger/port/elog_port.c
@@ -35,6 +35,7 @@
 
 #ifdef ELOG_FILE_ENABLE
 #include <elog_file.h>
+#include <elog_file_cfg.h>
 #endif
 static pthread_mutex_t output_lock;
 
@@ -49,7 +50,23 @@ ElogErrCode elog_port_init(void) {
     pthread_mutex_init(&output_lock, NULL);
 
 #ifdef ELOG_FILE_ENABLE
+    static char logfile[128];
+    time_t t = time(NULL);
+    struct tm tm_info;
+    localtime_r(&t, &tm_info);
+    snprintf(logfile, sizeof(logfile), "/tmp/elog_%04d%02d%02d_%02d%02d%02d.log",
+             tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday,
+             tm_info.tm_hour, tm_info.tm_min, tm_info.tm_sec);
+
+    printf("log file: %s\n", logfile);
+
     elog_file_init();
+    ElogFileCfg cfg = {
+            .name = logfile,
+            .max_size = ELOG_FILE_MAX_SIZE,
+            .max_rotate = ELOG_FILE_MAX_ROTATE,
+    };
+    elog_file_config(&cfg);
 #endif
 
     return result;

--- a/easylogger/CMakeLists.txt
+++ b/easylogger/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(easylogger
+    src/elog.c
+    src/elog_async.c
+    src/elog_buf.c
+    src/elog_utils.c
+    ../demo/os/linux/easylogger/port/elog_port.c
+    ../demo/os/linux/easylogger/port/elog_file_port.c
+    plugins/file/elog_file.c
+)
+
+target_include_directories(easylogger PUBLIC
+    ../demo/os/linux/easylogger/inc
+    inc
+    plugins/file
+)
+
+target_link_libraries(easylogger PUBLIC pthread)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(example
+    main.c
+    module_a/module_a.c
+    module_b/module_b.c
+)
+
+target_link_libraries(example easylogger pthread)

--- a/example/main.c
+++ b/example/main.c
@@ -1,0 +1,33 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <elog.h>
+#include "module_a/module_a.h"
+#include "module_b/module_b.h"
+
+int main(void) {
+    setbuf(stdout, NULL);
+    if (elog_init() != ELOG_NO_ERR) {
+        printf("elog init failed\n");
+        return -1;
+    }
+    elog_set_fmt(ELOG_LVL_INFO, ELOG_FMT_ALL); 
+    elog_set_fmt(ELOG_LVL_WARN, ELOG_FMT_ALL); 
+    elog_set_fmt(ELOG_LVL_DEBUG, ELOG_FMT_ALL);
+    elog_set_fmt(ELOG_LVL_VERBOSE, ELOG_FMT_ALL);
+#ifdef ELOG_COLOR_ENABLE
+    elog_set_text_color_enabled(true);
+#endif
+    elog_start();
+
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, module_a_thread, NULL);
+    pthread_create(&t2, NULL, module_b_thread, NULL);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    elog_stop();
+    elog_deinit();
+
+    return 0;
+}

--- a/example/module_a/module_a.c
+++ b/example/module_a/module_a.c
@@ -1,0 +1,12 @@
+#define LOG_TAG "moduleA"
+#include <elog.h>
+#include <unistd.h>
+#include "module_a.h"
+
+void* module_a_thread(void* arg) {
+    for(int i=0;i<5;i++) {
+        log_i("A loop %d", i);
+        usleep(200000);
+    }
+    return NULL;
+}

--- a/example/module_a/module_a.h
+++ b/example/module_a/module_a.h
@@ -1,0 +1,4 @@
+#ifndef MODULE_A_H
+#define MODULE_A_H
+void* module_a_thread(void* arg);
+#endif

--- a/example/module_b/module_b.c
+++ b/example/module_b/module_b.c
@@ -1,0 +1,12 @@
+#define LOG_TAG "moduleB"
+#include <elog.h>
+#include <unistd.h>
+#include "module_b.h"
+
+void* module_b_thread(void* arg) {
+    for(int i=0;i<5;i++) {
+        log_w("B loop %d", i);
+        usleep(250000);
+    }
+    return NULL;
+}

--- a/example/module_b/module_b.h
+++ b/example/module_b/module_b.h
@@ -1,0 +1,4 @@
+#ifndef MODULE_B_H
+#define MODULE_B_H
+void* module_b_thread(void* arg);
+#endif


### PR DESCRIPTION
## Summary
- add top-level CMake project
- build EasyLogger as a library using linux port
- create multithreaded example demonstrating async file logging
- generate unique log file name on each run

## Testing
- `cmake ..`
- `cmake --build .`
- `./example/example`

------
https://chatgpt.com/codex/tasks/task_e_68825ddc60dc83209bae26436e7c9e2a